### PR TITLE
demolish obsolete blocking logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 !*.*
 
 server
+client

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -68,7 +68,7 @@ static int32_t request_send(int fd, const uint8_t *text, size_t len) {
     return write_all(fd, wbuf.data(), wbuf.size());
 }
 
-static int32_t response_read(int fd, const uint8_t *res, size_t len){
+static int32_t response_read(int fd){
     std::vector<uint8_t>rbuf;
     // read response header
     rbuf.resize(4);
@@ -114,12 +114,24 @@ int main() {
         perror(nullptr);
         exit(EXIT_FAILURE);
     }
-    /*
-    int32_t err = query(fd, "testing 1");
-    if (err) { goto L_DONE;}
 
-    err = query(fd, "testing 2");
-    if (err) { goto L_DONE;} */
+    // send batch of requests
+    std::vector<std::string> queries = { "hello1", "hello2", "hello3"};
+    for (const std::string &s : queries) {
+        int32_t err = request_send(fd, (uint8_t *)s.data(), s.size());
+        if (err) {
+            perror("request not sent to server");
+            goto L_DONE;
+        }
+    }
+    // take a batch of responses
+    for (size_t i; i < queries.size(); i++) {
+        int32_t err = response_read(fd);
+        if (err) {
+            perror("server response not read");
+            goto L_DONE;
+        }
+    }
 
     L_DONE:
         close(fd);

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -31,7 +31,7 @@ static int32_t read_full(int fd, uint8_t *buf, size_t n){
         }
 
         assert((size_t)rv <= n);
-        buf += n;
+        buf += rv;
         n -= (size_t)rv;
         }
     return 0;
@@ -117,7 +117,12 @@ int main() {
     }
 
     // send batch of requests
-    std::vector<std::string> queries = { "hello1", "hello2", "hello3"};
+    std::vector<std::string> queries = { 
+        "hello1", "hello2", "hello3",
+        std::string(k_max_msg, 'z'),
+        "hello5"
+
+    };
     for (const std::string &s : queries) {
         int32_t err = request_send(fd, (uint8_t *)s.data(), s.size());
         if (err) {

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -58,7 +58,7 @@ static int32_t write_all(int fd, const uint8_t *buf, size_t n) {
 static int32_t request_send(int fd, const uint8_t *text, size_t len) {
     // check the length of the message against max limit
     if (len > k_max_msg) {
-        perror("request exceeds permitted length.");
+        perror("request exceeds permitted length");
         return -1;
     }
     // creat write buffer, fill it with request body and write to socket
@@ -74,27 +74,28 @@ static int32_t response_read(int fd){
     rbuf.resize(4);
     int32_t err = read_full(fd, &rbuf[0], 4);
     if (err) {
-        perror(errno == 0 ? "Unexpected EOF. Check connection." : "No response from server.");
+        perror(errno == 0 ? "Unexpected EOF. Check connection" : "No response from server");
         return err;
     }
     // get response length
-    uint8_t len = 0;
+    uint32_t len = 0;
     memcpy(&len, &rbuf[0], 4);
     if (len > k_max_msg) {
-        perror("Server response exceeds permitted length.");
+        perror("Server response exceeds permitted length");
+        return -1;
     }
-    return -1;
     
     //read response body
     rbuf.resize(4 + len);
-    int32_t err = read_full(fd, &rbuf[4], len);
+    err = read_full(fd, &rbuf[4], len);
     if (err) {
-        perror("Error reading server response body.");
+        perror("Error reading server response body");
         return err;
     }
 
     // print the response now that you have it
     printf("server says-> len: %u, data: %.*s\n", len, (len < 100 ? len : 100), &rbuf[4]);
+    return 0;
 }
 
 int main() {
@@ -125,7 +126,7 @@ int main() {
         }
     }
     // take a batch of responses
-    for (size_t i; i < queries.size(); i++) {
+    for (size_t i = 0; i < queries.size(); i++) {
         int32_t err = response_read(fd);
         if (err) {
             perror("server response not read");

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -55,6 +55,19 @@ static int32_t write_all(int fd, const uint8_t *buf, size_t n) {
     return 0;
 }
 
+static int32_t request_send(int fd, const uint8_t *text, size_t len) {
+    // check the length of the message against max limit
+    if (len > k_max_msg) {
+        perror("request exceeds permitted length.");
+        return -1;
+    }
+    // creat write buffer, fill it with request body and write to socket
+    std::vector<uint8_t>wbuf;
+    append_buffer(wbuf, (const uint8_t *)&len, 4);
+    append_buffer(wbuf, text, len);
+    return write_all(fd, wbuf.data(), wbuf.size());
+}
+
 int main() {
     
     int fd {socket(AF_INET, SOCK_STREAM, 0)};

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -9,7 +9,7 @@
 #include <sys/fcntl.h>
 
 
-const size_t k_max_msg = 4096;  
+const size_t k_max_msg = 32 << 20;  
 
 static void set_nonblocking(int fd) {
     // get current file status flags
@@ -56,7 +56,7 @@ static int32_t read_full(int fd, char *buf, size_t n){
         }
 
         assert((size_t)rv <= n);
-        buf += n;
+        buf += rv;
         n -= (size_t)rv;
         }
     return 0;

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -30,6 +30,15 @@ static void set_nonblocking(int fd) {
     }
 }
 
+// append client data to incoming buffer
+static void append_buffer(std::vector<uint8_t> &buf, const uint8_t *data, size_t len) {
+    buf.insert(buf.end(), data, data + len);
+}
+// delete client data from the front of a buffer
+static void consume_buffer(std::vector<uint8_t> &buf, size_t n) {
+    buf.erase(buf.begin(), buf.begin() + n);
+}
+
 // functions to read & write in loops
 // given by `n`, the number of bytes to be read or written
 static int32_t read_full(int fd, char *buf, size_t n){

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -107,6 +107,8 @@ static Connected *connection_accept(int fd) {
     Connected *connected = new Connected();
     connected->fd = connfd;
     connected->want_read = true; // safe bet, check if data is available and move on if it isn’t
+
+    return connected;
 }
 
 static void nb_read(Connected *connected) {
@@ -156,7 +158,7 @@ static void nb_write(Connected *connected) {
     // do a single non-bloacking write 
     // first make sure there's actually something in ::outgoing to write to this client
     assert(connected->outgoing.size() > 0);
-    size_t rv = write(connected->fd, connected->outgoing.data(), connected->outgoing.size());
+    ssize_t rv = write(connected->fd, connected->outgoing.data(), connected->outgoing.size());
     if (rv < 0) {
         if (errno == EINTR) {
             perror("RETRY: signal interrupted");
@@ -190,9 +192,9 @@ static void nb_write(Connected *connected) {
 }
 
 static bool try_single_request(Connected *connected) {
-    // try to parse the accumulated buffer
-    // process the parsed message
-    // remove the message from incoming bufffer
+    /* try to parse the accumulated buffer
+        process the parsed message
+        remove the message from incoming buffer  */
 
     // check that the data suffices a header at least
     if (connected->incoming.size() < 4) {

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -8,7 +8,6 @@
 #include <poll.h>
 #include <sys/fcntl.h>
 
-const size_t k_max_message = 4096;
 
 static void set_nonblocking(int fd) {
     // get current file status flags

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -26,7 +26,7 @@ static void set_nonblocking(int fd) {
     // set flag
     errno = 0;
     if (fcntl(fd, F_SETFL, flags) == -1) {
-        perror("fcntl(F_SETFL failed.");
+        perror("fcntl(F_SETFL) failed.");
         exit(EXIT_FAILURE);
     }
 }
@@ -144,7 +144,7 @@ static void nb_read(Connected *connected) {
     // put everything read from rbuf into ::incoming for this connection
     append_buffer(connected->incoming, rbuf, (size_t)rv);
     // check if the data in the buffer makes a complete request
-    try_single_request(connected);
+    while (try_single_request(connected)) {}
 
     // if the program has response for this connection, change flag to write
     if (connected->outgoing.size() > 0) {   
@@ -215,7 +215,10 @@ static bool try_single_request(Connected *connected) {
 
     const uint8_t *request = &connected->incoming[4];
 
-    // echo client message (for now)
+    // request parsed, print it for your own sake
+    printf("client msg-> len: %u, data: %.*s\n", len, (len < 100 ? len : 100), request);
+
+    // echo client message (for now) from the server
     // so just take the data from ::incoming and put in ::outgoing
     append_buffer(connected->outgoing, (const uint8_t *)&len, 4);
     append_buffer(connected->outgoing, request, len);

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -9,6 +9,8 @@
 #include <sys/fcntl.h>
 
 
+const size_t k_max_msg = 4096;  
+
 static void set_nonblocking(int fd) {
     // get current file status flags
     errno = 0;
@@ -107,7 +109,7 @@ static Connected *connection_accept(int fd) {
     connected->want_read = true; // safe bet, check if data is available and move on if it isn’t
 }
 
-static void nb_read (Connected *connected){
+static void nb_read(Connected *connected) {
     // do a single non-blocking read
     uint8_t rbuf[64 *1024];
     ssize_t rv = read(connected->fd, rbuf, sizeof(rbuf));

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -5,8 +5,29 @@
 #include <iostream>
 #include <unistd.h>
 #include <cassert>
+#include <sys/fcntl.h>
 
 const size_t k_max_message = 4096;
+
+static void set_nonblocking(int fd) {
+    // get current file status flags
+    errno = 0;
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags == -1) {
+        perror("fcntl(F_GETFL) failed.");
+        exit(EXIT_FAILURE);
+    }
+
+    // combining acquired flag with NONBLOCK
+    flags |= O_NONBLOCK;
+
+    // set flag
+    errno = 0;
+    if (fcntl(fd, F_SETFL, flags) == -1) {
+        perror("fcntl(F_SETFL failed.");
+        exit(EXIT_FAILURE);
+    }
+}
 
 // functions to read & write in loops
 // given by `n`, the number of bytes to be read or written

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -81,6 +81,23 @@ struct Connected {
     std::vector<uint8_t> outgoing;  // response data from the app, to be sent
     };
 
+static Connected *connection_accept(int fd) {
+    // create stuct to store address info
+    struct sockaddr_in client_addr = {};
+    socklen_t addrlen = sizeof(client_addr);
+    // accept
+    int connfd = accept(fd, (sockaddr *)&client_addr, &addrlen);
+    if (connfd < 0) {
+        return NULL;
+    }
+    set_nonblocking(connfd); // set nb for connfd so accept is nonblocking
+
+    // use connnect to populate a new Conn object
+    Connected *connected = new Connected();
+    connected->fd = connfd;
+    connected->want_read = true; // safe bet, check if data is available and move on if it isn’t
+}
+
 int main(){
 
     // listening socket fd

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -8,23 +8,6 @@
 
 const size_t k_max_message = 4096;
 
-static void interact(int connfd) {
-    char rbuf[k_max_message] = {};
-    ssize_t n = read(connfd, rbuf, sizeof(rbuf) - 1);
-    if (n < 0) {
-        std::cerr << "read() failed: " << strerror(errno) << std::endl;
-        return;
-    }
-    if (n == 0) {
-        std::cerr << "client disconnected" << std::endl;
-        return;
-    }
-    std::cout << "client msg received: " << rbuf << std::endl;
-
-    char wbuf[64] = "acknowledged\n";
-    write(connfd, wbuf, strlen(wbuf));
-}
-
 // functions to read & write in loops
 // given by `n`, the number of bytes to be read or written
 static int32_t read_full(int fd, char *buf, size_t n){
@@ -65,60 +48,16 @@ static int32_t write_all(int fd, const char *buf, size_t n) {
     return 0;
 }
 
-// this is to ensure messages are read/written completely and no bytes are dropped
-// will utilise the read_full and write_all functions from before
-static int32_t request_from(int connfd) {
-   
-    // buffer initialised with 4-byte header and maximum msg size we set earlier as a const
-    // header stores the length of the incoming message so we know how to handle it
-    // we will attempt to read the header 
-    char rbuf[4 + k_max_message];
-    errno = 0; // reset errno because it doesnt reset automatically on successful runs
-    size_t err = read_full(connfd, rbuf, 4);
-    if (err) {
-        std::cerr << (errno == 0 ? "EOF" : "read() error") << std::endl;
-        return err;
-    }
-
-    // copying the first 4 bytes of the header to `len`
-    uint32_t len = 0;
-    memcpy(&len, rbuf, 4); //assume this is little edian
-    // if the length of the message is longer than the size we've allocated for it, we wanna know
-    if (len > k_max_message) {
-        std::cerr << ("request message is too long.") << std::endl;
-        return -1;
-    }
-    // now to read the message. read from rbuf[4] because we already read the first 4 bytes
-    // everything in the buffer from [4] is the actual msg. before that is the header
-    err = read_full(connfd, &rbuf[4], len);
-    if (err) {
-        std::cerr << "error reading request message" << std::endl;
-    }
-    // okay so we have our message, we do something with it
-    // for now we just print it ig
-    printf("client msg: %.*s\n" ,len, &rbuf[4]);
-
-    // send a response
-    const char response[] = "message received";
-    char wbuf[4 + sizeof(response)];
-    len = (uint32_t)strlen(response);
-    memcpy(wbuf, &len, 4);
-    memcpy(&wbuf[4],response, len);
-    return write_all(connfd, wbuf, 4 + len);
-}
-
 int main(){
 
-    //creating the socket in IPv4 type TCP
+    // listening socket fd
     int fd = socket(AF_INET, SOCK_STREAM, 0);
 
-    //configuring a setting for the socket.
-    //SO_REUSEADDR set to 1. the socket is now allowed to reuse its address
+    // allow the socket to reuse its address
     int val = 1;
     setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
     
-    // an instance of the sockaddr struct that stores IPv4 addr info
-    //bound to our fd; rv - return value - handles error
+    // populate socket address and bind
     struct sockaddr_in addr = {};
     addr.sin_family = AF_INET;
     addr.sin_port = htons(1234);  //port given - htons() converts host port no. to network short
@@ -131,31 +70,12 @@ int main(){
         exit(EXIT_FAILURE);
     }
 
-    //the socket is actually created after listen()
-    //only parameters have been passed up to this point
+    // listen for incoming connections
     rv = listen(fd, SOMAXCONN);
     if (rv) {
         std::cerr << "listen() failed: " << strerror(errno) << std::endl;
         exit(EXIT_FAILURE);
     }
 
-    //configure the server to accept connections
-    while (true) {
-        struct sockaddr_in client_addr = {};
-        socklen_t addrlen = sizeof(client_addr);
-        int connfd = accept(fd, (struct sockaddr *)&client_addr, &addrlen);
-        if (connfd < 0) {
-            continue;
-        }
-        
-        // try to process all incoming requests on this connection
-        while (true) {
-            int rv = request_from(connfd);
-            if (rv < 0) { // error reading request or client closed connection
-                break;
-            }
-        }
-        close(connfd);
-    }
     return 0;
 }

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -127,5 +127,13 @@ int main(){
         exit(EXIT_FAILURE);
     }
 
+    // set listening socket to non-blocking
+    set_nonblocking(fd);
+
+    // mapping client connections to fds, keyed by fd
+    std::vector<Connected *>fd_conn_map;
+
+    
+
     return 0;
 }

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -69,6 +69,18 @@ static int32_t write_all(int fd, const char *buf, size_t n) {
     return 0;
 }
 
+struct Connected {
+    // client socket handle
+    int fd = -1;
+    // application intention in the event loop
+    bool want_read = false;
+    bool want_write = false;
+    bool want_close = false;
+    // buffering i/o
+    std::vector<uint8_t> incoming;  // data to be parsed by the application
+    std::vector<uint8_t> outgoing;  // response data from the app, to be sent
+    };
+
 int main(){
 
     // listening socket fd

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -224,7 +224,7 @@ static bool try_single_request(Connected *connected) {
     return true; // successfully parsed a complete message - (bool) let the caller know
 }
 
-int main(){
+int main() {
 
     // listening socket fd
     int fd = socket(AF_INET, SOCK_STREAM, 0);

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -31,11 +31,11 @@ static void set_nonblocking(int fd) {
     }
 }
 
-// append client data to incoming buffer
+// add data to the back of a buffer
 static void append_buffer(std::vector<uint8_t> &buf, const uint8_t *data, size_t len) {
     buf.insert(buf.end(), data, data + len);
 }
-// delete client data from the front of a buffer
+// delete data from the front of a buffer
 static void consume_buffer(std::vector<uint8_t> &buf, size_t n) {
     buf.erase(buf.begin(), buf.begin() + n);
 }


### PR DESCRIPTION
## ⚙️ Refactor: Non-Blocking Event Loop Implementation

This draft pull request begins the replacement of the blocking TCP server/client architecture with a non-blocking event loop. This will introduce major architectural changes and render parts of the existing program obsolete.

The goal is to align closely with the architecture described in the [Build Your Own Redis](https://build-your-own.org/redis/).

The new implementation will allow the server (`tcp_serv.cpp`) to:
- Accept multiple client connections concurrently
- Handle I/O events using a custom event loop without relying on threads or blocking sockets

This is a **low-level overhaul**, and all previous blocking logic is being removed or replaced.

---

### 🛠️ Files Affected
- `tcp_serv.cpp`: Fully refactored to implement non-blocking socket behavior via a custom event loop
- `tcp_client.cpp`: Will be updated later to test compatibility with the event-driven server

---

### 📋 TODO (Event Loop Refactor)

#### Core Infrastructure
- [x] Implement `fd_set_nb()` to set FDs as non-blocking
- [x] Use `poll()` for readiness-based event multiplexing
- [x] Create `Conn` struct to track:
  - FD number
  - I/O intention (`want_read`, `want_write`)
  - Input/output buffers
  - Close signal (`want_close`)
- [x] Maintain `std::vector<Conn*> fd2conn` to map FDs to connection objects

#### Connection Management
- [x] Accept new connections with `handle_accept()`
- [x] Set client FDs to non-blocking mode
- [x] Store new `Conn` instances in `fd2conn`

#### Event Loop Logic
- [x] Build `poll_args` list for `poll()` syscall:
  - Always include listening socket at index 0
  - Include all active connections with appropriate `POLLIN`/`POLLOUT` flags
- [x] On readiness:
  - If `POLLIN`, call `handle_read()`
  - If `POLLOUT`, call `handle_write()`
  - On `POLLERR` or `conn->want_close`, clean up connection

#### Read/Write Handlers
- [x] Implement `handle_read()` to:
  - Read into buffer
  - Detect EOF or errors
  - Call `try_one_request()` to parse and handle requests
- [x] Implement `try_one_request()` to:
  - Validate and extract full messages (length-prefixed)
  - Echo back data by populating `outgoing`
- [x] Implement `handle_write()` to:
  - Flush `outgoing` buffer
  - Update `want_read`/`want_write` flags

#### Final Steps
- [x] Add basic testing via `tcp_client.cpp`
- [x] Confirm proper handling of client disconnects
- [x] Confirm multiple concurrent clients can be served without blocking

---

### 🧾 Notes

- This implementation does not yet include RESP parsing, Redis commands, or a backing store — the focus is entirely on core event loop mechanics.
- The legacy blocking server architecture has been removed to make room for the new model.
- The design emphasises simplicity and extensibility in preparation for later features.

---

### 🚧 Status

This pull request is in **draft** while the event loop is being built and integrated. Once the server can manage multiple concurrent connections correctly and respond appropriately to clients, the PR will be marked ready for review and merged into `main`.