### PR TITLE
key-value server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,3 @@
-# Exclude all compiled binaries (common patterns)
-*.exe       # Windows executables
-*.out       # Unix executables (e.g., compiled with gcc)
-*.dll       # Windows libraries
-*.o         # Object files
-*.a         # Static libraries
-
-# OR ignore all files with no extension (common for Unix executables)
-*.
-!*.*
-
 server
 client
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 server
 client
+.DS_Store

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <cassert>
 
-const size_t max_msg = 32 << 20;
+const size_t max_msg = 4 * 1024;
 
 // add data to the back of a buffer
 static void append_buffer(std::vector<uint8_t> &buf, const uint8_t *data, size_t len) {
@@ -77,7 +77,7 @@ static int32_t request_send(int fd, const std::vector<std::string> &cmd) {
         memcpy(&wbuf[pos + sizeof(arglen)], s.data(), arglen);
         pos += sizeof(arglen) + arglen;
     }
-    return write_all(fd, wbuf, sizeof(wbuf));
+    return write_all(fd, wbuf, 4 + len);
 }
 
 static int32_t response_read(int fd) {
@@ -86,7 +86,7 @@ static int32_t response_read(int fd) {
     int32_t err = read_full(fd, rbuf, 4);   // read length prefix
     if (err) {
         if (errno == 0) {
-            printf("EOF");
+            printf("EOF\n");
         } else {
             perror("response not received from server"); }
         return err;

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <cassert>
 
-const size_t k_max_msg = 32 << 20;
+const size_t max_msg = 32 << 20;
 
 // add data to the back of a buffer
 static void append_buffer(std::vector<uint8_t> &buf, const uint8_t *data, size_t len) {
@@ -57,7 +57,7 @@ static int32_t write_all(int fd, const uint8_t *buf, size_t n) {
 
 static int32_t request_send(int fd, const uint8_t *text, size_t len) {
     // check the length of the message against max limit
-    if (len > k_max_msg) {
+    if (len > max_msg) {
         perror("request exceeds permitted length");
         return -1;
     }
@@ -80,7 +80,7 @@ static int32_t response_read(int fd){
     // get response length
     uint32_t len = 0;
     memcpy(&len, &rbuf[0], 4);
-    if (len > k_max_msg) {
+    if (len > max_msg) {
         perror("Server response exceeds permitted length");
         return -1;
     }
@@ -119,7 +119,7 @@ int main() {
     // send batch of requests
     std::vector<std::string> queries = { 
         "hello1", "hello2", "hello3",
-        std::string(k_max_msg, 'z'),
+        std::string(max_msg, 'z'),
         "hello5"
 
     };

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -134,20 +134,21 @@ int main(int argc, char **argv) {
         exit(EXIT_FAILURE);
     }
 
-    std::vector<std::string> cmd;
-    for (int i = 1; i < argc; ++i) {
-        cmd.push_back(argv[i]);
-    }
+    while (true) {
+        std::vector<std::string> cmd;
+        for (int i = 1; i < argc; ++i) {
+            cmd.push_back(argv[i]);
+        }
 
-    int32_t err = request_send(fd, cmd);
-    if (err) {
-        goto L_DONE;
+        int32_t err = request_send(fd, cmd);
+        if (err) {
+            goto L_DONE;
+        }
+        err = response_read(fd);
+        if (err) {
+            goto L_DONE;
+        }
     }
-    err = response_read(fd);
-    if (err) {
-        goto L_DONE;
-    }
-
 
     L_DONE:
         close(fd);

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -134,20 +134,18 @@ int main(int argc, char **argv) {
         exit(EXIT_FAILURE);
     }
 
-    while (true) {
-        std::vector<std::string> cmd;
-        for (int i = 1; i < argc; ++i) {
-            cmd.push_back(argv[i]);
-        }
+    std::vector<std::string> cmd;
+    for (int i = 1; i < argc; ++i) {
+        cmd.push_back(argv[i]);
+    }
 
-        int32_t err = request_send(fd, cmd);
-        if (err) {
-            goto L_DONE;
-        }
-        err = response_read(fd);
-        if (err) {
-            goto L_DONE;
-        }
+    int32_t err = request_send(fd, cmd);
+    if (err) {
+        goto L_DONE;
+    }
+    err = response_read(fd);
+    if (err) {
+        goto L_DONE;
     }
 
     L_DONE:

--- a/tcp_client.cpp
+++ b/tcp_client.cpp
@@ -116,7 +116,7 @@ static int32_t response_read(int fd) {
     return 0;
 }
 
-int main() {
+int main(int argc, char **argv) {
     
     int fd {socket(AF_INET, SOCK_STREAM, 0)};
     int reuseBool {1};
@@ -134,32 +134,22 @@ int main() {
         exit(EXIT_FAILURE);
     }
 
-    // send batch of requests
-    std::vector<std::string> queries = { 
-        "hello1", "hello2", "hello3",
-        std::string(max_msg, 'z'),
-        "hello5"
-
-    };
-    /* for (const std::string &s : queries) {
-        int32_t err = request_send(fd, (uint8_t *)s.data(), s.size());
-        if (err) {
-            perror("request not sent to server");
-            goto L_DONE;
-        }
-    } */
-    // take a batch of responses
-    for (size_t i = 0; i < queries.size(); i++) {
-        int32_t err = response_read(fd);
-        if (err) {
-            perror("server response not read");
-            goto L_DONE;
-        }
+    std::vector<std::string> cmd;
+    for (int i = 1; i < argc; ++i) {
+        cmd.push_back(argv[i]);
     }
+
+    int32_t err = request_send(fd, cmd);
+    if (err) {
+        goto L_DONE;
+    }
+    err = response_read(fd);
+    if (err) {
+        goto L_DONE;
+    }
+
 
     L_DONE:
         close(fd);
         return 0;
-
-    return 0;
 }

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -95,7 +95,7 @@ struct Connected {
     };
 
 struct Response {
-    uint8_t status = 0;
+    uint32_t status = 0;
     std::vector<uint8_t>data;
 };
 
@@ -204,7 +204,7 @@ static void respond(const Response &response, std::vector<uint8_t> &out) {
     uint32_t responselength = 4 + (uint32_t)response.data.size();
     append_buffer(out, (const uint8_t *)&responselength, 4);    // header - entire msg length prefix
     append_buffer(out, (const uint8_t *)&response.status, 4);   // status code
-    append_buffer(out, response.data.data(), response.data.size());     // payload
+    append_buffer(out, response.data.data(), response.data.size());    // payload
 }
 
 static bool try_single_request(Connected *connected) {
@@ -435,7 +435,7 @@ int main() {
             if ((ready & POLLERR) || connected->want_close) {
                 // close the connection on error
                 // OR close on flag intent
-                std::cout << "CLOSED CLIENT CONNECTION" << std::endl;
+                std::cout << "CLOSED CLIENT CONNECTION\n" << std::endl;
                 (void)close(connected->fd);
                 fd_conn_map[connected->fd] = NULL;
                 delete connected;

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <poll.h>
 #include <sys/fcntl.h>
+#include <map>
 
 
 const size_t max_msg = 32 << 20;
@@ -168,6 +169,8 @@ static int32_t requestParse(const uint8_t *data, size_t size, std::vector<std::s
     return 0;
 }
 
+static std::map<std::string, std::string>archive;
+
 static bool try_single_request(Connected *connected) {
     /*  1. try to parse the accumulated buffer
         2. process the parsed message
@@ -205,7 +208,6 @@ static bool try_single_request(Connected *connected) {
     // Response struct
     // do_request()
     // make_response()
-    // parse_req(request, len, cmd)
     /*
     Response resp;
     do_request(cmd, resp);

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -111,6 +111,7 @@ static Connected *connection_accept(int fd) {
     socklen_t addrlen = sizeof(client_addr);
     // accept
     int connfd = accept(fd, (sockaddr *)&client_addr, &addrlen);
+    printf("client connection accepted\n");
     if (connfd < 0) {
         return NULL;
     }
@@ -330,6 +331,7 @@ int main() {
 
     // listening socket fd
     int fd = socket(AF_INET, SOCK_STREAM, 0);
+    printf("\nintialising socket...\n");
 
     // allow the socket to reuse its address
     int val = 1;
@@ -342,6 +344,7 @@ int main() {
     addr.sin_addr.s_addr = htonl(0); //wildcard 0.0.0.0 - htonl() converts addr to net long
 
     int rv  = bind(fd, (const struct sockaddr *)&addr, sizeof(addr));
+    printf("binding address...\n");
     if (rv) {
         std::cerr << "bind() failed: ";
         perror(nullptr); // This will print the error message corresponding to errno
@@ -350,6 +353,7 @@ int main() {
 
     // listen for incoming connections
     rv = listen(fd, SOMAXCONN);
+    printf("listening...\n");
     if (rv) {
         std::cerr << "listen() failed: " << strerror(errno) << std::endl;
         exit(EXIT_FAILURE);
@@ -364,6 +368,7 @@ int main() {
     // event loop
     std::vector<pollfd> socketNotifiers; // list of socket notifiers
     while (true) {
+
         socketNotifiers.clear();
         // listening socket first into notifiers
         struct pollfd askListen = {fd, POLLIN, 0};
@@ -387,6 +392,7 @@ int main() {
             }
             if (rv < 0) {
                 std::cerr << "poll() failure" << std::endl;
+                return -1;
             }
 
         /* if program is here, then at least one of the sockets is ready, its notifier active */

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -239,7 +239,7 @@ static bool try_single_request(Connected *connected) {
         connected->want_close = true;
         return false;
     }
-    // check for close command
+    // check for close command (?)
     if ((cmd.size() == 1) && cmd[0] == "close") {
         connected->want_close = true;
         return true;
@@ -272,17 +272,14 @@ static void nb_read(Connected *connected) {
             return;
         }
     }
+    // shutdown client read
     if (rv == 0){
-        /*
-        if (connected->incoming.empty()){
-            printf("request RECEIVED");
-            return;
+        if (connected->incoming.size() == 0) {
+            printf("client connection closed");
         } else {
-            perror("CLOSE: unexpected EOF");
-            connected->want_close = true; // EOF - ask to close connection
-            return;
-        }   
-        */
+            printf("unexpected client EOF");
+        }
+        connected->want_close = true;
         return;
     }
     // put everything read from rbuf into ::incoming for this connection

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -93,6 +93,10 @@ struct Connected {
     std::vector<uint8_t> outgoing;  // response data from the app, to be sent
     };
 
+struct Response {
+    uint8_t status = 0;
+    std::vector<uint8_t>data;
+};
 
 static Connected *connection_accept(int fd) {
     // create stuct to store address info

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -274,9 +274,7 @@ static void nb_read(Connected *connected) {
     }
     // shutdown client read
     if (rv == 0){
-        if (connected->incoming.size() == 0) {
-            printf("client connection closed");
-        } else {
+        if (connected->incoming.size() != 0) {
             printf("unexpected client EOF");
         }
         connected->want_close = true;
@@ -361,7 +359,7 @@ int main() {
 
     // listen for incoming connections
     rv = listen(fd, SOMAXCONN);
-    printf("listening...\n");
+    printf("listening...\n\n");
     if (rv) {
         std::cerr << "listen() failed: " << strerror(errno) << std::endl;
         exit(EXIT_FAILURE);
@@ -435,7 +433,8 @@ int main() {
                 nb_write(connected);
             }
             if ((ready & POLLERR) || connected->want_close) {
-                // error, close the connection
+                // close the connection on error
+                // OR close on flag intent
                 std::cout << "CLOSED CLIENT CONNECTION" << std::endl;
                 (void)close(connected->fd);
                 fd_conn_map[connected->fd] = NULL;

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -199,6 +199,13 @@ static void do_request(std::vector<std::string> &cmd, Response &out) {
     }
 }
 
+static void respond(const Response &response, std::vector<uint8_t> &out) {
+    uint32_t responselength = 4 + (uint32_t)response.data.size();
+    append_buffer(out, (const uint8_t *)&responselength, 4);    // header - entire msg length prefix
+    append_buffer(out, (const uint8_t *)&response.status, 4);   // status code
+    append_buffer(out, response.data.data(), response.data.size());     // payload
+}
+
 static bool try_single_request(Connected *connected) {
     /*  1. try to parse the accumulated buffer
         2. process the parsed message
@@ -223,18 +230,12 @@ static bool try_single_request(Connected *connected) {
 
     const uint8_t *request = &connected->incoming[4];
     // (kv-server) - *request points to (what will be) the beginning of the cmd payload
-                    //  outer byte size header is stripped bcus atp, its a valid msg. 
+                    //  outer byte size header has been stripped bcuz atp, its a valid msg. 
                     // the logic you do now is INSIDE that msg, relevant to the redis
-    
-
     /*
     request parsed, print it for your own sake
     printf("client msg-> len: %u, data: %.*s\n", len, (len < 100 ? len : 100), request);
     */
-
-    // request_parse() !!!
-    // Response struct
-    // do_request()
     // make_response()
     /*
     Response resp;

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -239,6 +239,11 @@ static bool try_single_request(Connected *connected) {
         connected->want_close = true;
         return false;
     }
+    // check for close command
+    if ((cmd.size() == 1) && cmd[0] == "close") {
+        connected->want_close = true;
+        return true;
+    }
 
     Response srv_resp;
     do_request(cmd, srv_resp);
@@ -268,19 +273,25 @@ static void nb_read(Connected *connected) {
         }
     }
     if (rv == 0){
+        /*
         if (connected->incoming.empty()){
-            connected->want_close = true; // close cleanly
+            printf("request RECEIVED");
             return;
         } else {
             perror("CLOSE: unexpected EOF");
             connected->want_close = true; // EOF - ask to close connection
             return;
-        }
+        }   
+        */
+        return;
     }
     // put everything read from rbuf into ::incoming for this connection
     append_buffer(connected->incoming, rbuf, (size_t)rv);
     // check if the data in the buffer makes a complete request
-    while (try_single_request(connected)) {}
+    while (try_single_request(connected)) {
+        printf("request RECEIVED\n");
+        fflush(stdout);
+    }
 
     // if the program has response for this connection, change flag to write
     if (connected->outgoing.size() > 0) {   

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -124,7 +124,7 @@ static Connected *connection_accept(int fd) {
     return connected;
 }
 static bool u32read(const uint8_t *&pos, const uint8_t *end, uint32_t &out){
-    if ((pos + 4) < end) {
+    if ((pos + 4) > end) {
         perror("cannot read size");
         return false;
     }
@@ -238,7 +238,7 @@ static bool try_single_request(Connected *connected) {
         connected->want_close = true;
         return false;
     }
-    
+
     Response srv_resp;
     do_request(cmd, srv_resp);
     respond(srv_resp, connected->outgoing);

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -99,6 +99,12 @@ struct Response {
     std::vector<uint8_t>data;
 };
 
+enum {
+    RES_OK = 0,
+    RES_ERR = 1,
+    RES_NO = 2,
+};
+
 static Connected *connection_accept(int fd) {
     // create stuct to store address info
     struct sockaddr_in client_addr = {};

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -232,16 +232,16 @@ static bool try_single_request(Connected *connected) {
     // (kv-server) - *request points to (what will be) the beginning of the cmd payload
                     //  outer byte size header has been stripped bcuz atp, its a valid msg. 
                     // the logic you do now is INSIDE that msg, relevant to the redis
-    /*
-    request parsed, print it for your own sake
-    printf("client msg-> len: %u, data: %.*s\n", len, (len < 100 ? len : 100), request);
-    */
-    // make_response()
-    /*
-    Response resp;
-    do_request(cmd, resp);
-    make_response(resp, conn->outgoing);
-        */
+    std::vector<std::string> cmd;
+    if (requestParse(request, len, cmd) < 0) {
+        perror("cannot parse client request");
+        connected->want_close = true;
+        return false;
+    }
+    
+    Response srv_resp;
+    do_request(cmd, srv_resp);
+    respond(srv_resp, connected->outgoing);
     // consume message from connected::incoming to clear the buffer
     consume_buffer(connected->incoming, 4 + len);
     return true; // successfully parsed a complete message - (bool) let the caller know

--- a/tcp_serv.cpp
+++ b/tcp_serv.cpp
@@ -177,6 +177,28 @@ static int32_t requestParse(const uint8_t *data, size_t size, std::vector<std::s
 
 static std::map<std::string, std::string>archive;
 
+static void do_request(std::vector<std::string> &cmd, Response &out) {
+    if ((cmd.size() == 2) && cmd[0] == "get") {
+        auto it = archive.find(cmd[1]);
+        if (it != archive.end()) {
+            const std::string &val = it->second;
+            out.data.assign(val.begin(), val.end());
+        } else {
+            out.status = RES_NO;
+            return;
+        }
+    }
+    else if ((cmd.size() == 3) && cmd[0] == "set") {
+        archive[cmd[1]].swap(cmd[2]);
+    }
+    else if ((cmd.size() == 2) && cmd[0] == "del") {
+        archive.erase(cmd[1]);
+    }
+    else {
+        out.status = RES_ERR;   // command was not recognised, error status
+    }
+}
+
 static bool try_single_request(Connected *connected) {
     /*  1. try to parse the accumulated buffer
         2. process the parsed message


### PR DESCRIPTION
# Transform TCP Echo Server into Redis-Style Key-Value Store

## Summary
This PR supercharges our humble TCP echo server, turning it into a functional, non-blocking, Redis-inspired key-value store. You can now `GET`, `SET` and `DEL` keys, all while retaining our efficient event-loop architecture.

---

## Changes

### Server
- **Key–Value Storage**  
  Introduced a `std::map<std::string, std::string>` for in-memory data persistence.  
- **Command Parser**  
  Parses Redis-like commands (`GET`, `SET`, `DEL`) with a 4-byte length-prefix protocol.  
- **Response Formatting**  
  Returns status codes (`OK`, `ERR`, `NO`) and data payloads for `GET`.  
- **Error Handling & Logging**  
  Enhanced robustness in socket operations and improved log output for easier debugging.

### Client
- **Protocol Support**  
  Rebuilt to send the new command format and interpret status codes.  
- **CLI Arguments**  
  Accepts commands directly via command-line flags.  
- **Resource Management**  
  Reduced max message size to prevent runaway memory usage.

---

## Implementation Details

### Command Protocol

    [4-byte total_length][4-byte num_elements]
      ├─ [4-byte len][bytes of "COMMAND"]
      ├─ [4-byte len][bytes of "key"]
      └─ [4-byte len][bytes of "value"]   ← only for SET


### Response Protocol
- **Status codes:**  
  - `0` = OK  
  - `1` = ERR  
  - `2` = NO (e.g. key not found)  
- **Data payload:**  
  On `GET`, includes the stored value after the status code.

### Non-Blocking I/O
Maintains the existing event loop for handling multiple clients concurrently, now with extended error checks around socket reads/writes.

---

## Testing
- ✅ `SET` stores keys reliably  
- ✅ `GET` retrieves values or returns `NOT_FOUND`  
- ✅ `DEL` removes entries  
- ✅ Multiple clients operate in parallel without blocking

---

## Future Work
1. **Persistence** to disk (AOF / RDB snapshots)  
2. Additional Redis commands
3. Client **authentication**  
4. More **granular error messages** and metrics